### PR TITLE
Coder Stencil Customization

### DIFF
--- a/src/GToolkit-World/GtCoderStencil.class.st
+++ b/src/GToolkit-World/GtCoderStencil.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #GtCoderStencil,
 	#superclass : #GtToolStencil,
+	#instVars : [
+		'coder'
+	],
 	#category : #'GToolkit-World-Stencils'
 }
 
@@ -9,9 +12,19 @@ GtCoderStencil >> asPreviewElement [
 	^ GtCoder new asElement
 ]
 
+{ #category : #accessing }
+GtCoderStencil >> coder [
+	^ coder ifNil: [ coder := GtCoder new ]
+]
+
+{ #category : #accessing }
+GtCoderStencil >> coder: aCoder [
+	coder := aCoder
+]
+
 { #category : #'api - instantiation' }
 GtCoderStencil >> create [
-	^ GtCoder new createInPager maximized.
+	^ self coder createInPager maximized
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Allows you to e.g. open a Coder on a particular package:
```smalltalk
coderStencil := GtCoderStencil new coder: (GtCoder forPackage: (RPackageOrganizer default packageNamed: 'MyPackage-Core')); yourself.
self
	showSpaceWithTitle: 'Coder'
	with: coderStencil create
	from: card 
```