### PR TITLE
Typo in the "JavaScript Debugger Setup & Example"

### DIFF
--- a/lepiter/9y7jowdtdfxenw1klw6t4n39s.lepiter
+++ b/lepiter/9y7jowdtdfxenw1klw6t4n39s.lepiter
@@ -403,7 +403,7 @@
 							"paragraphStyle" : {
 								"__type" : "textStyle"
 							},
-							"string" : "You get a debugger window that shows you the python code. You can step over or run and the execution will continue and still produce the result."
+							"string" : "You get a debugger window that shows you the JavaScript code. You can step over or run and the execution will continue and still produce the result."
 						}
 					]
 				},


### PR DESCRIPTION
Typo improved from "python code" to "JavaScript code"

 {{gtPage:JavaScript Debugger Setup & Example|db=2j9m7db2i4oz116bexd7wbdxo}}